### PR TITLE
Allow videoplay on whereby.com Fixes brave/brave-browser#7037

### DIFF
--- a/data/autoplay.json
+++ b/data/autoplay.json
@@ -33,6 +33,6 @@
         "uphold.com",
         "sandbox.uphold.com",
         "veriff.me",
-		"whereby.com"
+        "whereby.com"
     ]
 }

--- a/data/autoplay.json
+++ b/data/autoplay.json
@@ -32,6 +32,7 @@
         "sliver.tv",
         "uphold.com",
         "sandbox.uphold.com",
-        "veriff.me"
+        "veriff.me",
+		"whereby.com"
     ]
 }


### PR DESCRIPTION
Okay, `https://whereby.com/` needs access access to camera/video. This should help streamline this request.  

Closing; https://github.com/brave/brave-browser/issues/7037