### PR TITLE
Fix autoplay on nfl.com

### DIFF
--- a/data/autoplay.json
+++ b/data/autoplay.json
@@ -10,6 +10,7 @@
         "giphy.com",
         "imgur.com",
         "netflix.com",
+        "nfl.com",
         "hulu.com",
         "primevideo.com",
         "dailymotion.com",


### PR DESCRIPTION
Fixes autoplay on `nfl.com` videos:

Example: `http://www.nfl.com/videos/nfl-network-total-access/0ap3000001097226/Larry-Fitzgerald-I-didn-t-need-to-be-lobbied-to-return-for-2020`