### PR TITLE
Fix autoplay on tidal.com

### DIFF
--- a/data/autoplay.json
+++ b/data/autoplay.json
@@ -25,6 +25,7 @@
         "pscp.tv",
         "hangouts.google.com",
         "meet.google.com",
+        "tidal.com",
         "rainway.com",
         "rainway.io",
         "cheddar.com",


### PR DESCRIPTION
Can't play through a playlist on `tidal.com` without autoplay blocking the next song.

This will allow `tidal.com` to work. (Tested with my subscription)