### PR TITLE
Fix Autoplay on nbc.com

### DIFF
--- a/data/autoplay.json
+++ b/data/autoplay.json
@@ -25,6 +25,7 @@
         "periscope.tv",
         "pscp.tv",
         "hangouts.google.com",
+        "nbc.com",
         "meet.google.com",
         "tidal.com",
         "rainway.com",


### PR DESCRIPTION
Allow autoplay on `nbc.com` Got an autoplay request on;

`https://www.nbc.com/night-gallery/video/the-dead-man/3965928`