### PR TITLE
Allow autoplay on twitter.com

### DIFF
--- a/data/autoplay.json
+++ b/data/autoplay.json
@@ -15,6 +15,7 @@
         "primevideo.com",
         "dailymotion.com",
         "tv.com",
+        "twitter.com",
         "contv.com",
         "metacafe.com",
         "d.tube",


### PR DESCRIPTION
Twitter has their own autoplay enabled on their site. we should let twitter autoplay videos (as the user scrolls). 

May fix a few false positives reports where people expect videos to play automatically based on other browsers.

If this is okay @pilgrim-brave 