### PR TITLE
Allow autoplay on disneyplus.com

### DIFF
--- a/data/autoplay.json
+++ b/data/autoplay.json
@@ -15,6 +15,7 @@
         "primevideo.com",
         "dailymotion.com",
         "tv.com",
+        "disneyplus.com",
         "twitter.com",
         "contv.com",
         "metacafe.com",


### PR DESCRIPTION
Autoplay notification on `disneyplus.com` should be allowed, since we're allowing Netflix. 