### PR TITLE
Fix autoplay on music.amazon.com

### DIFF
--- a/data/autoplay.json
+++ b/data/autoplay.json
@@ -7,6 +7,7 @@
         "vimeo.com",
         "udemy.com",
         "duolingo.com",
+        "music.amazon.com",
         "giphy.com",
         "imgur.com",
         "netflix.com",


### PR DESCRIPTION
Autoplay is needed on `https://music.amazon.com/`  was reported https://community.brave.com/t/amazon-music-playback-disabled-windows-10/109315 and tested.

@pilgrim-brave 