### PR TITLE
Allow autoplay on music site gaana.com

### DIFF
--- a/data/autoplay.json
+++ b/data/autoplay.json
@@ -8,6 +8,7 @@
         "udemy.com",
         "duolingo.com",
         "music.amazon.com",
+        "gaana.com",
         "giphy.com",
         "imgur.com",
         "netflix.com",


### PR DESCRIPTION
Fixing playback issue, noticed autoplay wasn't working on this Indian music site.

Was reported here; https://community.brave.com/t/network-error-in-playing-music-in-gaana-com/109700

Any questions let me know @pilgrim-brave 