### PR TITLE
Allow autoplay on idomoo.com

### DIFF
--- a/data/autoplay.json
+++ b/data/autoplay.json
@@ -10,6 +10,7 @@
         "music.amazon.com",
         "gaana.com",
         "giphy.com",
+        "idomoo.com",
         "imgur.com",
         "netflix.com",
         "nfl.com",


### PR DESCRIPTION
Was reported by the user, video backdrop wasn't working on `idomoo.com` due to autoplay. Just a quick fix to allow this.