### PR TITLE
Fix Autoplay on hbo.com

### DIFF
--- a/data/autoplay.json
+++ b/data/autoplay.json
@@ -10,6 +10,7 @@
         "music.amazon.com",
         "gaana.com",
         "giphy.com",
+        "hbo.com",
         "idomoo.com",
         "imgur.com",
         "netflix.com",


### PR DESCRIPTION
Fixes autoplay on `https://www.hbo.com/avenue-5`

 @pilgrim-brave 