### PR TITLE
Allow autoplay on cwtv.com

### DIFF
--- a/data/autoplay.json
+++ b/data/autoplay.json
@@ -6,6 +6,7 @@
         "twitch.tv",
         "vimeo.com",
         "udemy.com",
+        "cwtv.com",
         "duolingo.com",
         "music.amazon.com",
         "gaana.com",


### PR DESCRIPTION
Should allow autoplay for `cwtv.com` 

@pilgrim-brave   Could check that autoplay working correctly on, seems to asking for permission even when autoplay is allowed, after a few refreshes.

`https://www.cwtv.com/shows/nancy-drew/the-real-cost/?play=1d66787a-fc19-4c68-b1be-2bb5472b66a3`

Was reported here: https://community.brave.com/t/unable-to-play-video-regardless-of-autoplay-setting/110891/5