### PR TITLE
Support building on node v12+

### DIFF
--- a/node_addon/AWParserWrap.cc
+++ b/node_addon/AWParserWrap.cc
@@ -48,7 +48,8 @@ namespace AWParserWrap {
         NODE_SET_PROTOTYPE_METHOD(tpl, "cleanup", CAWParserWrap::Cleanup);
 
         constructor.Reset(isolate, tpl->GetFunction(isolate->GetCurrentContext()).ToLocalChecked());
-        exports->Set(String::NewFromUtf8(isolate, "CAWParser", NewStringType::kNormal).ToLocalChecked(),
+        exports->Set(isolate->GetCurrentContext(),
+                     String::NewFromUtf8(isolate, "CAWParser", NewStringType::kNormal).ToLocalChecked(),
                      tpl->GetFunction(isolate->GetCurrentContext()).ToLocalChecked());
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -587,9 +587,8 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "hashset-cpp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/hashset-cpp/-/hashset-cpp-2.2.1.tgz",
-      "integrity": "sha512-pO16ApkT0SEtXmCy9FgcwwPnTUbdRzL000gcpOtJyIY3OOSYvh4eQaZdYjlU+Y1AOzy3am6msgHZZ5Yok19aLw=="
+      "version": "github:bbondy/hashset-cpp#e283e264477c68227bb394ff8eaa7dd44d57578f",
+      "from": "github:bbondy/hashset-cpp#e283e264477c68227bb394ff8eaa7dd44d57578f"
     },
     "he": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/brave/autoplay-whitelist#readme",
   "dependencies": {
-    "hashset-cpp": "^2.2.1",
+    "hashset-cpp": "github:bbondy/hashset-cpp#e283e264477c68227bb394ff8eaa7dd44d57578f",
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.3",
     "node-gyp": "^5.0.3"


### PR DESCRIPTION
Thanks to bbondy/hashset-cpp#5 and an additional small change, I'm able to get this building on more recent Node versions (including the current 15.6.x version).